### PR TITLE
Postage Stamps basic views

### DIFF
--- a/stginga/gingawrapper.py
+++ b/stginga/gingawrapper.py
@@ -17,58 +17,57 @@ __all__ = ['run_stginga']
 
 # Manage the default layout. Yes, OMG, hacky hacky
 gmain.default_layout = ['seq', {}, [
-    'vpanel', {}, [
-        'vbox', {'name': 'top', 'width': 1520, 'height': 900},
-        {'row': ['hbox', {'name': 'menu'}], 'stretch': 0},
-        {'row': [
-            'hpanel', {'name': 'hpnl'},
-            [
-                'ws', {'name': 'left', 'width': 300, 'group': 2},
+    'vbox',  {'name': 'top', 'width': 1520, 'height': 900},
+    {'row': ['hbox', {'name': 'menu'}], 'stretch': 0},
+    {'row': [
+        'vpanel', {}, [
+            'vbox', {},
+            {'row': [
+                'hpanel', {'name': 'hpnl'}, [
+                    'ws', {'name': 'left', 'width': 300, 'group': 2}, [
+                        ('Info', [
+                            'vpanel', {}, [
+                                'ws', {'name': 'uleft', 'height': 300,
+                                       'show_tabs': False, 'group': 3}
+                            ],
+                            [
+                                'ws', {'name': 'lleft', 'height': 430,
+                                       'show_tabs': True, 'group': 3}
+                            ]
+                        ])
+                    ]
+                ],
                 [
-                    ('Info', [
-                        'vpanel', {},
-                        [
-                            'ws', {'name': 'uleft', 'height': 300,
-                                   'show_tabs': False, 'group': 3}
-                        ],
-                        [
-                            'ws', {'name': 'lleft', 'height': 430,
-                                   'show_tabs': True, 'group': 3}
-                        ]
-                    ])
+                    'vbox', {'name': 'main', 'width': 700},
+                    {'row': [
+                        'ws', {'wstype': 'tabs', 'name': 'channels',
+                               'group': 1}
+                    ],
+                     'stretch': 1
+                    }
+                ],
+                [
+                    'ws', {'name': 'right', 'width': 430, 'group': 2}, [
+                        ('Dialogs', [
+                            'ws', {'name': 'dialogs', 'group': 2}
+                        ])
+                    ]
                 ]
             ],
-            [
-                'vbox', {'name': 'main', 'width': 700},
-                {'row':
-                 [
-                     'ws', {'wstype': 'tabs', 'name': 'channels',
-                            'group': 1}
-                 ],
-                 'stretch': 1
-                }
-            ],
-            [
-                'ws', {'name': 'right', 'width': 430, 'group': 2},
-                [
-                    ('Dialogs', [
-                        'ws', {'name': 'dialogs', 'group': 2}
-                    ])
-                ]
-            ]
+             'stretch': 1}, [
+                 'ws', {'name': 'toolbar', 'height': 40,
+                        'show_tabs': False, 'group': 2}
+             ]
         ],
-         'stretch': 1},
         [
-            'ws', {'name': 'toolbar', 'height': 40,
-                   'show_tabs': False, 'group': 2}
+            'hbox', {'name': 'pstamps'}
         ],
-        {'row':
-         [
-             'hbox', {'name': 'status'}
-         ],
-         'stretch': 0
-        }
-    ]
+    ]},
+    {'row': [
+        'hbox', {'name': 'status'}
+    ],
+     'stretch': 0
+    }
 ]]
 
 

--- a/stginga/gingawrapper.py
+++ b/stginga/gingawrapper.py
@@ -16,36 +16,60 @@ logging.raiseExceptions = False
 __all__ = ['run_stginga']
 
 # Manage the default layout. Yes, OMG, hacky hacky
-gmain.default_layout = ['seq', {},
-                        ['vbox', dict(name='top', width=1520, height=900),
-                         dict(row=['hbox', dict(name='menu')],
-                              stretch=0),
-                         dict(row=['hpanel', dict(name='hpnl'),
-                                   ['ws', dict(name='left', width=300, group=2),
-                                    # (tabname, layout), ...
-                                    [("Info", ['vpanel', {},
-                                               ['ws', dict(name='uleft', height=300,
-                                                           show_tabs=False, group=3)],
-                                               ['ws', dict(name='lleft', height=430,
-                                                           show_tabs=True, group=3)],
-                                    ]
-                                    )]],
-                                   ['vbox', dict(name='main', width=700),
-                                    dict(row=['ws', dict(wstype='tabs', name='channels',
-                                                         group=1)], stretch=1)],
-                                   ['ws', dict(name='right', width=430, group=2),
-                                    # (tabname, layout), ...
-                                    [("Dialogs", ['ws', dict(name='dialogs', group=2)
-                                    ]
-                                    )]
-                                   ],
-                         ], stretch=1),
-                         dict(row=['ws', dict(name='toolbar', height=40,
-                                              show_tabs=False, group=2)],
-                              stretch=0),
-                         dict(row=['hbox', dict(name='pstamps')]),
-                         dict(row=['hbox', dict(name='status')], stretch=0),
-                        ]]
+gmain.default_layout = ['seq', {}, [
+    'vpanel', {}, [
+        'vbox', {'name': 'top', 'width': 1520, 'height': 900},
+        {'row': ['hbox', {'name': 'menu'}], 'stretch': 0},
+        {'row': [
+            'hpanel', {'name': 'hpnl'},
+            [
+                'ws', {'name': 'left', 'width': 300, 'group': 2},
+                [
+                    ('Info', [
+                        'vpanel', {},
+                        [
+                            'ws', {'name': 'uleft', 'height': 300,
+                                   'show_tabs': False, 'group': 3}
+                        ],
+                        [
+                            'ws', {'name': 'lleft', 'height': 430,
+                                   'show_tabs': True, 'group': 3}
+                        ]
+                    ])
+                ]
+            ],
+            [
+                'vbox', {'name': 'main', 'width': 700},
+                {'row':
+                 [
+                     'ws', {'wstype': 'tabs', 'name': 'channels',
+                            'group': 1}
+                 ],
+                 'stretch': 1
+                }
+            ],
+            [
+                'ws', {'name': 'right', 'width': 430, 'group': 2},
+                [
+                    ('Dialogs', [
+                        'ws', {'name': 'dialogs', 'group': 2}
+                    ])
+                ]
+            ]
+        ],
+         'stretch': 1},
+        [
+            'ws', {'name': 'toolbar', 'height': 40,
+                   'show_tabs': False, 'group': 2}
+        ],
+        {'row':
+         [
+             'hbox', {'name': 'status'}
+         ],
+         'stretch': 0
+        }
+    ]
+]]
 
 
 def run_stginga(sys_argv):

--- a/stginga/gingawrapper.py
+++ b/stginga/gingawrapper.py
@@ -15,6 +15,38 @@ logging.raiseExceptions = False
 
 __all__ = ['run_stginga']
 
+# Manage the default layout. Yes, OMG, hacky hacky
+gmain.default_layout = ['seq', {},
+                        ['vbox', dict(name='top', width=1520, height=900),
+                         dict(row=['hbox', dict(name='menu')],
+                              stretch=0),
+                         dict(row=['hpanel', dict(name='hpnl'),
+                                   ['ws', dict(name='left', width=300, group=2),
+                                    # (tabname, layout), ...
+                                    [("Info", ['vpanel', {},
+                                               ['ws', dict(name='uleft', height=300,
+                                                           show_tabs=False, group=3)],
+                                               ['ws', dict(name='lleft', height=430,
+                                                           show_tabs=True, group=3)],
+                                    ]
+                                    )]],
+                                   ['vbox', dict(name='main', width=700),
+                                    dict(row=['ws', dict(wstype='tabs', name='channels',
+                                                         group=1)], stretch=1)],
+                                   ['ws', dict(name='right', width=430, group=2),
+                                    # (tabname, layout), ...
+                                    [("Dialogs", ['ws', dict(name='dialogs', group=2)
+                                    ]
+                                    )]
+                                   ],
+                         ], stretch=1),
+                         dict(row=['ws', dict(name='toolbar', height=40,
+                                              show_tabs=False, group=2)],
+                              stretch=0),
+                         dict(row=['hbox', dict(name='pstamps')]),
+                         dict(row=['hbox', dict(name='status')], stretch=0),
+                        ]]
+
 
 def run_stginga(sys_argv):
     """Run this from command line.

--- a/stginga/plugins/MultiImage.py
+++ b/stginga/plugins/MultiImage.py
@@ -108,8 +108,10 @@ class MultiImage(GingaPlugin.LocalPlugin):
         fi_image = self.fitsimage.get_image()
         if fi_image is None:
             return
-        fi_image_id = fi_image.get('path', None)
-        if fi_image_id is None:
+        try:
+            fi_image_id = fi_image.get('path')
+        except Exception as e:
+            raise
             fi_image_id = self.make_id()
         try:
             _, pickimage = self.images[fi_image_id]
@@ -138,7 +140,7 @@ class MultiImage(GingaPlugin.LocalPlugin):
                                                   int(x2), int(y2))
             self.logger.debug("cut box %f,%f %f,%f" % (x1, y1, x2, y2))
             pickimage.set_data(data)
-            pickimage.zoom_fit()
+            #pickimage.zoom_fit()
 
     def stop(self):
         self.logger.debug('Called.')
@@ -228,6 +230,7 @@ class MultiImage(GingaPlugin.LocalPlugin):
         di = Viewers.ImageViewCanvas(logger=self.logger)
         di.configure_window(50, 50)
         di.enable_autozoom('on')
+        di.add_callback('configure', self.window_resized_cb)
         di.enable_autocuts('off')
         di.set_bg(0.4, 0.4, 0.4)
         # for debugging
@@ -298,3 +301,7 @@ class MultiImage(GingaPlugin.LocalPlugin):
     def make_id(self):
         self.id_count += 1
         return 'Image_{:02}'.format(self.id_count)
+
+    def window_resized_cb(self, fitsimage, width, height):
+        self.logger.debug('Called.')
+        fitsimage.zoom_fit()

--- a/stginga/plugins/MultiImage.py
+++ b/stginga/plugins/MultiImage.py
@@ -16,6 +16,7 @@ class MultiImage(GingaPlugin.LocalPlugin):
         super(MultiImage, self).__init__(fv, fitsimage)
 
         self.logger.debug('Called.')
+        self.logger.debug('fv.w="{}"'.format(self.fv.w))
 
         self.dc = self.fv.getDrawClasses()
 
@@ -33,7 +34,7 @@ class MultiImage(GingaPlugin.LocalPlugin):
         canvas.set_draw_mode('move')
         self.canvas = canvas
 
-        self.id_count = 0 # Create unique ids
+        self.id_count = 0  # Create unique ids
 
         self.layertag = 'muimg-canvas'
         self.dx = 30
@@ -48,18 +49,20 @@ class MultiImage(GingaPlugin.LocalPlugin):
         """Build the Dialog"""
         self.logger.debug('Called.')
 
+        # Postage stamps
+        self.logger.debug('pstamps="{}"'.format(self.fv.w['pstamps']))
+        pstamps = Widgets.HBox()
+        w = pstamps.get_widget()
+        self.fv.w['pstamps'].layout().addWidget(w)
+        self.pstamps = pstamps
+        return
+
         # Get container specs.
         vbox, sw, orientation = Widgets.get_oriented_box(container)
         vbox.set_border_width(4)
         vbox.set_spacing(2)
 
-        # Overall container
-        vtop = Widgets.VBox()
-        vtop.set_border_width(4)
-        vtop.add_widget(sw, stretch=1)
-        self.vtop = vtop
-
-        # Instructiopns
+        # Instructions
         self.msgFont = self.fv.getFont("sansFont", 12)
         tw = Widgets.TextArea(wrap=True, editable=False)
         tw.set_font(self.msgFont)
@@ -69,7 +72,9 @@ class MultiImage(GingaPlugin.LocalPlugin):
         fr.set_widget(tw)
         vbox.add_widget(fr, stretch=0)
 
-        container.add_widget(vtop, stretch=1)
+        vjunk = Widgets.VBox()
+        vjunk.set_border_width(4)
+        container.add_widget(vjunk, stretch=1)
 
     def instructions(self):
         self.tw.set_text(instructions)
@@ -78,7 +83,7 @@ class MultiImage(GingaPlugin.LocalPlugin):
     def start(self):
         self.logger.debug('Called.')
 
-        self.instructions()
+        #self.instructions()
 
         # insert layer if it is not already
         p_canvas = self.fitsimage.get_canvas()
@@ -221,8 +226,7 @@ class MultiImage(GingaPlugin.LocalPlugin):
 
         # Setup for thumbnail display
         di = Viewers.ImageViewCanvas(logger=self.logger)
-        width, height = 200, 200
-        di.configure_window(width, height)
+        di.configure_window(50, 50)
         di.enable_autozoom('on')
         di.enable_autocuts('off')
         di.set_bg(0.4, 0.4, 0.4)
@@ -230,7 +234,7 @@ class MultiImage(GingaPlugin.LocalPlugin):
         di.set_name('pickimage')
 
         iw = Widgets.wrap(di.get_widget())
-        self.vtop.add_widget(iw)
+        self.pstamps.add_widget(iw)
 
         return di
 


### PR DESCRIPTION
This moves the postage stamps underneath the display. Work involved redefining the reference viewer layout.

Resolves issues #2, #13
