### PR TITLE
Undo explicit capitalization of channel name

### DIFF
--- a/stginga/plugins/DQInspect.py
+++ b/stginga/plugins/DQInspect.py
@@ -253,7 +253,6 @@ To inspect the whole image: Select one or more desired DQ flags from the list. A
                 return self._reset_imdq_on_error()
 
             chname = self.fv.get_channelName(self.fitsimage)
-            chname = chname.capitalize()  # Temp fix?
             chinfo = self.fv.get_channelInfo(chname)
 
             if dqname in chinfo.datasrc:  # DQ already loaded


### PR DESCRIPTION
Undo explicit capitalization of channel name; not needed anymore after latest Ginga bug fix. See ejeschke/ginga#218.
