### PR TITLE
Catch out of bound errors and issue warnings instead

### DIFF
--- a/stginga/plugins/BackgroundSub.py
+++ b/stginga/plugins/BackgroundSub.py
@@ -239,14 +239,19 @@ Click "Subtract" to remove background.""")
                 self.boxwidth, self.boxheight)
 
         # Extract background data
-        bg_masked = image.cutout_shape(bg_obj)
-        bg_data = bg_masked[~bg_masked.mask]
-        self.bgval = calc_stat(bg_data, sigma=self.sigma, niter=self.niter,
-                               algorithm=self.algorithm)
+        try:
+            bg_masked = image.cutout_shape(bg_obj)
+            bg_data = bg_masked[~bg_masked.mask]
+        except Exception as e:
+            self.logger.warn('{0}: {1}'.format(e.__class__.__name__, str(e)))
+            self.bgval = self._dummy_value
+        else:
+            self.bgval = calc_stat(bg_data, sigma=self.sigma, niter=self.niter,
+                                   algorithm=self.algorithm)
+
         self._debug_str += (', bgval={0}, salgo={1}, sigma={2}, '
                             'niter={3}'.format(
-                self.bgval, self.algorithm, self.sigma, self.niter))
-
+            self.bgval, self.algorithm, self.sigma, self.niter))
         self.logger.debug(self._debug_str)
         self.w.background_value.set_text(str(self.bgval))
 

--- a/stginga/plugins/DQInspect.py
+++ b/stginga/plugins/DQInspect.py
@@ -329,13 +329,19 @@ To inspect the whole image: Select one or more desired DQ flags from the list. A
             dqsrc.metadata[self._cache_key] = pixmask_by_flag
 
         # Parse DQ into individual flag definitions
-        pixval = data[int(self.ycen), int(self.xcen)]
-        dqs = dqparser.interpret_dqval(pixval)
-        self.w.dq.set_text(str(pixval))
-        for row in dqs:
-            item = QtGui.QListWidgetItem(
-                '{0:<5d}\t{1}'.format(row[dqparser._dqcol], row[self.dqstr]))
-            self.pxdqlist.addItem(item)
+        ix = int(self.xcen)
+        iy = int(self.ycen)
+        if (0 <= iy < data.shape[0]) and (0 <= ix < data.shape[1]):
+            pixval = data[iy, ix]
+            dqs = dqparser.interpret_dqval(pixval)
+            self.w.dq.set_text(str(pixval))
+            for row in dqs:
+                item = QtGui.QListWidgetItem('{0:<5d}\t{1}'.format(
+                    row[dqparser._dqcol], row[self.dqstr]))
+                self.pxdqlist.addItem(item)
+        else:
+            self.logger.warn('{0}[{1}, {2}] is out of range; data shape is '
+                             '{3}'.format(dqname, iy, ix, data.shape))
 
         # No need to do the rest if image has not changed
         if pixmask_by_flag is self._curpxmask:


### PR DESCRIPTION
Catch out of bound errors and issue warnings instead. This fixes #53 and more.
