### PR TITLE
Relaxed BackgroundSub check for science ext

### DIFF
--- a/stginga/plugins/BackgroundSub.py
+++ b/stginga/plugins/BackgroundSub.py
@@ -214,8 +214,11 @@ Click "Subtract" to remove background.""")
 
         header = image.get_header()
         extname = header.get(self._ext_key, self._no_keyword).upper()
-        if extname != self._sci_extname:
-            self.logger.debug(
+
+        # Only calculate for science extension.
+        # If EXTNAME does not exist, just assume user knows best.
+        if extname not in (self._sci_extname, self._no_keyword):
+            self.logger.warn(
                 'Background calculation not possible for {0} extension in '
                 '{1}'.format(extname, image.get('name')))
             return True


### PR DESCRIPTION
Relaxed `BackgroundSub` check for science extension.

This is because the plugin refused to calculate background value for an input image with no extension (only has `PRIMARY`) and no `EXTNAME` defined in its header. It was looking for `EXTNAME = 'SCI'` (by default) to verify that the data is indeed from science extension (not ERR or DQ) as per _standard_ HST multi-extension FITS format from the Archive. 

I guess it needs to be a bit more flexible to account for the fact that users can have FITS images with incomplete header, etc.

c/c @stscieisenhamer 
