### PR TITLE
A plethora of plugins changes

### DIFF
--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,3 +1,2 @@
 astropy >= 1.0
 ginga
-numpydoc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,14 +31,12 @@ import shlex
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'numpydoc',
+    'sphinx.ext.napoleon',
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
     'sphinx.ext.pngmath',
     'sphinx.ext.viewcode',
 ]
-
-numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -292,14 +290,14 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
 
-
-# Example configuration for intersphinx: refer to the Python standard library.
+# Configuration for intersphinx
 intersphinx_mapping = {
     'python': ('http://docs.python.org/', None),
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
     'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
     'matplotlib': ('http://matplotlib.org/', None),
-    'astropy': ('http://docs.astropy.org/en/stable/', None)
+    'astropy': ('http://docs.astropy.org/en/latest/', None),
+    'ginga': ('http://ginga.readthedocs.org/en/latest/', None)
     }
 
 # a simple/non-configurable extension that generates the rst files for ipython

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -3,9 +3,93 @@
 Configuration Files
 ===================
 
-To use STScI recommended settings, copy the ``*.cfg`` files from
-``stginga/ginga/examples/configs`` to your ``$HOME/.ginga`` directory.
-If you already have existing Ginga configuration files, it is recommended that
-you **back up your existing Ginga configurations** before copying the files
-over. You can further customize Ginga according to your own preferences
-afterwards by modifying them manually.
+To use STScI recommended settings, refer to the ``*.cfg`` files in
+``stginga/examples/configs``. You can modify your existing configurations
+using the given values in the examples, or copy the files directly to your
+``$HOME/.ginga`` directory. The latter is *not* recommended unless you know what
+you are doing (and remember to **back up your existing Ginga configurations**
+before copying). You can further customize Ginga according to your own
+preferences afterwards by modifying them again manually.
+
+Note that our versions of *existing* Ginga configuration files do not have
+a complete list of possible configuration values. We simply list the values
+that we recommend for overriding Ginga defaults. For a full list, please refer
+to the respective examples in ``ginga/examples/configs``.
+
+Our own plugin configurations are described with their respective
+:ref:`stginga-plugins`. Meanwhile, we explain the importance of overriding some
+Ginga defaults for use with STScI data below.
+
+
+.. _stginga-general-cfg:
+
+general.cfg
+-----------
+
+Due to the fact that some plugins can modify image buffers in memory
+(e.g., :ref:`local-plugin-backgroundsub`), it is recommended that Ginga's data
+cache is set to never expire (at the risk of memory error if you open more
+images than your machine can handle). If this is not set, you might lose any
+changes to your data buffer when the image is reloaded from file:
+
+.. code-block:: python
+
+    numImages = 0
+
+.. note::
+
+    If you use ``channel_<channelname>.cfg`` (e.g., ``channel_Image.cfg``),
+    you also need to set ``numImages`` there appropriately, as it overrides
+    the general setting.
+
+In addition, our plugins also use some general settings that are specific to
+STScI FITS data structure. If they are not set, HST defaults are used:
+
+.. code-block:: python
+
+    # Inherit PRIMARY (EXT=0) header for multi-extension FITS
+    inherit_primary_header = True
+
+    # Header keywords. These can be in PRIMARY header only if it is inherited.
+    # Otherwise, Ginga will only look in the specified extension.
+    extnamekey = 'EXTNAME'
+    extverkey = 'EXTVER'
+    sciextname = 'SCI'
+    errextname = 'ERR'
+    dqextname = 'DQ'
+    instrumentkey = 'INSTRUME'
+    targnamekey = 'TARGNAME'
+
+
+.. _stginga-contents-cfg:
+
+plugin_Contents.cfg
+-------------------
+
+Ginga's default columns for
+`Contents plugin <https://ginga.readthedocs.org/en/latest/manual/plugins.html#contents>`_
+do not apply to STScI FITS data. Therefore, you should customize it to show
+keyword values that are relevant to your own data. However, you should *always*
+keep ``NAME`` and ``MODIFIED`` because they are used to identify the image
+buffer and specify whether the buffer has changed, respectively. For example:
+
+.. code-block:: python
+
+    # Columns to show from metadata
+    # Format: [(col header, keyword1), ... ]
+    columns = [ ('Name', 'NAME'), ('Object', 'TARGNAME'), ..., ('Modified', 'MODIFIED')]
+
+
+.. _stginga-thumbs-cfg:
+
+plugin_Thumbs.cfg
+-----------------
+
+Ginga's default keywords for
+`Thumbs plugin <https://ginga.readthedocs.org/en/latest/manual/plugins.html#thumbs>`_
+do not apply to STScI FITS data. Therefore, you should customize it to show
+keyword values that are relevant to your own data. For example:
+
+.. code-block:: python
+
+    tt_keywords = ['EXTNAME', 'EXTVER', 'NAXIS1', 'NAXIS2']

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -5,7 +5,7 @@ Installation
 
 ``stginga`` requires:
 
-* Astropy 1.0 or later, available from
+* Astropy 1.1 or later, available from
   `Astropy's GitHub page <https://github.com/astropy/astropy>`_.
 * The latest version of Ginga, available from
   `Ginga's GitHub page <https://github.com/ejeschke/ginga/>`_.
@@ -13,7 +13,7 @@ Installation
   `stginga's GitHub page <https://github.com/spacetelescope/stginga>`_.
 
 We suggest using  `Anaconda <https://www.continuum.io/downloads>`_ as a
-python distribution that is known to work with ``stginga``.
+Python distribution that is known to work with ``stginga``.
 
 To install ``stginga`` from source::
 

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -44,6 +44,32 @@ It is customizable using ``~/.ginga/plugin_BackgroundSub.cfg``::
   sigma = 1.8
   niter = 10
 
+  # If set to True, only use good pixels for calculations.
+  # This is only applicable if there is an associated DQ extension.
+  # Can also be changed in the GUI.
+  ignore_bad_pixels = False
+
+
+.. _local-plugin-changehistory:
+
+ChangeHistory
+-------------
+
+This plugin is used to log any changes to data buffer. It is customizable using
+``~/.ginga/plugin_ChangeHistory.cfg``::
+
+  #
+  # ChangeHistory plugin preferences file
+  #
+  # Place this in file under ~/.ginga with the name "plugin_ChangeHistory.cfg"
+
+  # If set to True, will always expand the tree in ChangeHistory when
+  # new entries are added
+  always_expand = True
+
+  # If set to True, rows will have alternate colors
+  color_alternate_rows = True
+
 
 .. _local-plugin-dqinspect:
 
@@ -98,6 +124,7 @@ update dynamically.
 Options include fixing the region either to sky coordinates, the
 default, or to pixels (data). Standard editing controls over the box
 are also available.
+
 
 .. _local-plugin-mipick:
 

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -3,7 +3,7 @@
 Plugins
 =======
 
-By using ``stginga``, the following plugins (in alphabetical order) are also
+By using ``stginga``, the following plugins are also
 available, in addition to the ones that already come with Ginga. Some are
 customizable via plugin configuration files, which are available in the
 `stginga/examples/configs <https://github.com/spacetelescope/stginga/tree/master/stginga/examples/configs>`_ directory.
@@ -14,7 +14,7 @@ customizable via plugin configuration files, which are available in the
 BackgroundSub
 -------------
 
-This plugin is used to calculate and subtract background value. Currently,
+This local plugin is used to calculate and subtract background value. Currently,
 it only handles constant background and there is no way to save the subtracted
 image. However, subtraction parameters can be saved to a JSON file, which then
 can be reloaded as well.
@@ -50,13 +50,16 @@ It is customizable using ``~/.ginga/plugin_BackgroundSub.cfg``::
   ignore_bad_pixels = False
 
 
-.. _local-plugin-changehistory:
+.. _global-plugin-changehistory:
 
 ChangeHistory
 -------------
 
-This plugin is used to log any changes to data buffer. It is customizable using
-``~/.ginga/plugin_ChangeHistory.cfg``::
+This global plugin is used to log any changes to data buffer. For example,
+a change log would appear here if background is subtracted off an image using
+:ref:`local-plugin-backgroundsub` plugin.
+
+It is customizable using ``~/.ginga/plugin_ChangeHistory.cfg``::
 
   #
   # ChangeHistory plugin preferences file
@@ -76,7 +79,7 @@ This plugin is used to log any changes to data buffer. It is customizable using
 DQInspect
 ---------
 
-This plugin is used to inspect the associated DQ array of a given image.
+This local plugin is used to inspect the associated DQ array of a given image.
 It shows the different DQ flags that went into a given pixel (middle right)
 and also the overall mask of the selected DQ flag(s) (bottom right).
 
@@ -110,7 +113,7 @@ It is customizable using ``~/.ginga/plugin_DQInspect.cfg``::
 MultiImage
 ----------
 
-This plugin is used to view a selectable region of sky in multiple
+This local plugin is used to view a selectable region of sky in multiple
 images. A box on the image in the main display defines the right
 ascension/declination region of sky to view. Along the bottom, postage
 stamps of that same region from other images loaded into Ginga are
@@ -119,7 +122,7 @@ update dynamically.
 
 .. image:: _static/multiimage_screenshot.png
   :width: 800px
-  :alt: DQInspect plugin
+  :alt: MultiImage plugin
 
 Options include fixing the region either to sky coordinates, the
 default, or to pixels (data). Standard editing controls over the box
@@ -131,16 +134,16 @@ are also available.
 MIPick
 ------
 
-This plugin is mainly a demonstration on how custom plugins can be
-integrated with existing plugins. This plugin is based on the ``Pick``
-plugin. However, the pick region, instead of being fixed to image
+This local plugin is mainly a demonstration on how custom plugins can be
+integrated with existing plugins. This plugin is based on the
+`Pick plugin <https://ginga.readthedocs.org/en/latest/manual/plugins.html#pick>`_.
+However, the pick region, instead of being fixed to image
 pixel coordinates, uses the image sky coordinates. If run with
-``MultiImage``, the postage stamps will show the same region in different
-images. Also, as images are cycled through the main viewer, the region
-will automatically update, again always fixed on the same section of
-sky.
+:ref:`local-plugin-multiimage`, the postage stamps will show the same region
+in different images.
+Also, as images are cycled through the main viewer, the region
+will automatically update, again always fixed on the same section of sky.
 
 .. image:: _static/mipick_screenshot.png
   :width: 800px
-  :alt: DQInspect plugin
-
+  :alt: MIPick plugin

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -104,8 +104,7 @@ It is customizable using ``~/.ginga/plugin_DQInspect.cfg``::
   pxdqcolor = 'red'
 
   # Color and opacity to mark all affected pixels
-  imdqcolor = 'blue'
-  imdqalpha = 1.0
+  imdqcolors = ['blue', 'magenta', 'green', ...]
 
 
 .. _local-plugin-multiimage:

--- a/docs/source/run.rst
+++ b/docs/source/run.rst
@@ -19,16 +19,13 @@ The stginga Script
 ------------------
 
 The simplest way is to simply use a script packaged with ``stginga`` that knows
-how to preload the :ref:`STScI plugins <stginga-plugins>`. Note that this
-currently only works when Ginga is run with the Qt backend::
+how to preload the :ref:`STScI plugins <stginga-plugins>`::
 
     stginga [args]
 
-The accepted command line arguments are the same as for standard Ginga,
-with the following exceptions:
-
-* There is no need to use ``--plugins`` and ``--modules`` to load STScI plugins.
-* Toolkit (``--toolkit`` or ``-t``) is always set to Qt.
+The accepted command line arguments are the same as for standard Ginga, except
+that there is no need to use ``--plugins`` and ``--modules`` to load
+STScI plugins.
 
 
 .. _stginga-run-gingaconfig:
@@ -51,11 +48,6 @@ Then, you can run Ginga natively as follows::
 
     ginga [args]
 
-Depending on how your system is set up, you might need to specify the toolkit,
-because ``stginga`` plugins are currently only available for Qt::
-
-    ginga --toolkit=qt [args]
-
 
 .. _stginga-run-manual:
 
@@ -64,6 +56,4 @@ Manually Load stginga Plugins
 
 You can also run Ginga natively and just specify the plugins you want directly::
 
-    ginga --plugins=stginga.plugins.BackgroundSub,stginga.plugins.DQInspect,stginga.plugins.MIPick,stginga.plugins.MultiImage [args]
-
-As in :ref:`stginga-run-gingaconfig`, Qt toolkit is required.
+    ginga --plugins=stginga.plugins.BackgroundSub,stginga.plugins.DQInspect,stginga.plugins.MIPick,stginga.plugins.MultiImage --modules=stginga.plugins.ChangeHistory [args]

--- a/stginga/examples/configs/channel_Image.cfg
+++ b/stginga/examples/configs/channel_Image.cfg
@@ -1,0 +1,11 @@
+#
+# Image channel preferences for Ginga
+#
+# Place this in file under ~/.ginga with the name "channel_Image.cfg"
+
+# Number of images to keep in memory per channel (0 = unlimited)
+# Same as numImages in general.cfg
+numImages = 0
+
+# Sort channel history ('loadtime' or 'alpha')
+sort_order = 'alpha'

--- a/stginga/examples/configs/general.cfg
+++ b/stginga/examples/configs/general.cfg
@@ -62,6 +62,7 @@ pixel_coords_offset = 1.0
 inherit_primary_header = True
 
 # Header keywords. These can be in PRIMARY header only if it is inherited.
+# Otherwise, Ginga will only look in the specified extension.
 extnamekey = 'EXTNAME'
 extverkey = 'EXTVER'
 sciextname = 'SCI'

--- a/stginga/examples/configs/plugin_BackgroundSub.cfg
+++ b/stginga/examples/configs/plugin_BackgroundSub.cfg
@@ -16,3 +16,8 @@
 #algorithm = 'median'
 #sigma = 1.8
 #niter = 10
+
+# If set to True, only use good pixels for calculations.
+# This is only applicable if there is an associated DQ extension.
+# Can also be changed in the GUI.
+#ignore_bad_pixels = False

--- a/stginga/examples/configs/plugin_ChangeHistory.cfg
+++ b/stginga/examples/configs/plugin_ChangeHistory.cfg
@@ -1,0 +1,11 @@
+#
+# ChangeHistory plugin preferences file
+#
+# Place this in file under ~/.ginga with the name "plugin_ChangeHistory.cfg"
+
+# If set to True, will always expand the tree in ChangeHistory when
+# new entries are added
+always_expand = True
+
+# If set to True, rows will have alternate colors
+color_alternate_rows = True

--- a/stginga/examples/configs/plugin_ChangeHistory.cfg
+++ b/stginga/examples/configs/plugin_ChangeHistory.cfg
@@ -5,7 +5,7 @@
 
 # If set to True, will always expand the tree in ChangeHistory when
 # new entries are added
-always_expand = True
+#always_expand = True
 
 # If set to True, rows will have alternate colors
-color_alternate_rows = True
+#color_alternate_rows = True

--- a/stginga/examples/configs/plugin_Contents.cfg
+++ b/stginga/examples/configs/plugin_Contents.cfg
@@ -3,9 +3,9 @@
 #
 # Place this in file under ~/.ginga with the name "plugin_Contents.cfg"
 
-# columns to show from metadata
-# format: [(col header, keyword1), ... ]
-columns = [ ('Name', 'NAME'), ('Object', 'TARGNAME'), ('Date', 'DATE-OBS'), ('Time UT', 'TIME-OBS'), ]
+# Columns to show from metadata
+# Format: [(col header, keyword1), ... ]
+columns = [ ('Name', 'NAME'), ('Object', 'TARGNAME'), ('Date', 'DATE-OBS'), ('Time UT', 'TIME-OBS'), ('Modified', 'MODIFIED')]
 
 # If set to True, will always expand the tree in Contents when
 # new entries are added

--- a/stginga/examples/configs/plugin_Contents.cfg
+++ b/stginga/examples/configs/plugin_Contents.cfg
@@ -7,5 +7,6 @@
 # format: [(col header, keyword1), ... ]
 columns = [ ('Name', 'NAME'), ('Object', 'TARGNAME'), ('Date', 'DATE-OBS'), ('Time UT', 'TIME-OBS'), ]
 
-# If set to True, will always expand the tree in Contents when new entries are added
+# If set to True, will always expand the tree in Contents when
+# new entries are added
 always_expand = True

--- a/stginga/examples/configs/plugin_DQInspect.cfg
+++ b/stginga/examples/configs/plugin_DQInspect.cfg
@@ -7,11 +7,10 @@
 #dqstr = 'long'
 
 # DQ definition files (JWST)
-dqdict = {'NIRCAM': 'data/dqflags_jwst.txt', 'NIRSPEC': 'data/dqflags_jwst.txt', 'NIRISS': 'data/dqflags_jwst.txt', 'MIRI': 'data/dqflags_jwst.txt', 'ACS': 'data/dqflags_acs.txt', 'WFC3': 'data/dqflags_wfc3.txt', 'COS': 'data/dqflags_hstgen.txt', 'STIS': 'data/dqflags_hstgen.txt', 'WFPC2': 'data/dqflags_hstgen.txt'}
+#dqdict = {'NIRCAM': 'data/dqflags_jwst.txt', 'NIRSPEC': 'data/dqflags_jwst.txt', 'NIRISS': 'data/dqflags_jwst.txt', 'MIRI': 'data/dqflags_jwst.txt', 'ACS': 'data/dqflags_acs.txt', 'WFC3': 'data/dqflags_wfc3.txt', 'COS': 'data/dqflags_hstgen.txt', 'STIS': 'data/dqflags_hstgen.txt', 'WFPC2': 'data/dqflags_hstgen.txt'}
 
 # Color to mark a single pixel for inspection
 #pxdqcolor = 'red'
 
 # Color and opacity to mark all affected pixels
-#imdqcolor = 'blue'
-#imdqalpha = 1.0
+#imdqcolors = ['blue', 'magenta', 'green']

--- a/stginga/examples/configs/plugin_Thumbs.cfg
+++ b/stginga/examples/configs/plugin_Thumbs.cfg
@@ -1,0 +1,15 @@
+#
+# Thumbs plugin preferences file
+#
+# Place this in file under ~/.ginga with the name "plugin_Thumbs.cfg"
+
+# Keywords to extract and show if we mouse over the thumbnail
+tt_keywords = ['EXTNAME', 'EXTVER', 'NAXIS1', 'NAXIS2']
+
+# How many seconds to wait after an image is altered to begin trying
+# to rebuild a matching thumb.  Usually a few seconds is good in case
+# there is ongoing adjustment of the image
+rebuild_wait = 4.0
+
+# Sort the thumbnails alphabetically
+sort_order = 'alpha'

--- a/stginga/gingawrapper.py
+++ b/stginga/gingawrapper.py
@@ -95,7 +95,6 @@ def run_stginga(sys_argv):
     This does the following:
 
     * Set up custom STScI plugins.
-    * Enforce Qt toolkit.
     * Pass command line arguments directly into Ginga.
 
     .. warning::
@@ -123,13 +122,13 @@ def run_stginga(sys_argv):
     gmain.global_plugins += stglobal_plugins
     gmain.local_plugins += stlocal_plugins
 
-    # Enforce Qt (--toolkit or -t)
-    new_argv = ['--toolkit=qt' if 'toolkit' in s else s for s in sys_argv]
-    if '-t' in new_argv:
-        new_argv[new_argv.index('-t') + 1] = 'qt'
+    # Enforce Qt (--toolkit or -t) -- DISABLED
+    #new_argv = ['--toolkit=qt' if 'toolkit' in s else s for s in sys_argv]
+    #if '-t' in new_argv:
+    #    new_argv[new_argv.index('-t') + 1] = 'qt'
 
     # Start Ginga
-    gmain.reference_viewer(new_argv)
+    gmain.reference_viewer(sys_argv)
 
 
 def _locate_plugin(plist, name):

--- a/stginga/plugin_info.py
+++ b/stginga/plugin_info.py
@@ -38,13 +38,16 @@ def load_plugins(ginga):
 def _get_stginga_plugins():
     gpfx = 'stginga.plugins'  # To load custom Qt plugins in Ginga namespace
 
-    global_plugins = []
+    global_plugins = [
+        Bunch(module='ChangeHistory', tab='History', ws='right', pfx=gpfx,
+              start=True),
+        ]
     local_plugins = [
         Bunch(module='BackgroundSub', ws='dialogs', pfx=gpfx),
         Bunch(module='DQInspect', ws='dialogs', pfx=gpfx),
         Bunch(module='MultiImage', ws='dialogs', pfx=gpfx),
         Bunch(module='MIPick', ws='dialogs', pfx=gpfx),
-    ]
+        ]
     return global_plugins, local_plugins
 
 

--- a/stginga/plugin_info.py
+++ b/stginga/plugin_info.py
@@ -36,7 +36,7 @@ def load_plugins(ginga):
 
 
 def _get_stginga_plugins():
-    gpfx = 'stginga.plugins'  # To load custom Qt plugins in Ginga namespace
+    gpfx = 'stginga.plugins'  # To load custom plugins in Ginga namespace
 
     global_plugins = [
         Bunch(module='ChangeHistory', tab='History', ws='right', pfx=gpfx,

--- a/stginga/plugins/BackgroundSub.py
+++ b/stginga/plugins/BackgroundSub.py
@@ -762,7 +762,9 @@ Click "Subtract" to remove background.""")
         self.logger.info(s)
 
         # Change data in Ginga object and recalculate BG in annulus
-        image.set_data(new_data, metadata=image.metadata)
+        metadata = image.metadata
+        metadata['_latest_modification'] = s  # For ChangeHistory plugin
+        image.set_data(new_data, metadata=metadata)
         #self.fitsimage.auto_levels()
 
         # Update file listing

--- a/stginga/plugins/BackgroundSub.py
+++ b/stginga/plugins/BackgroundSub.py
@@ -14,7 +14,6 @@ from astropy.utils.misc import JsonCustomEncoder
 
 # GINGA
 from ginga import GingaPlugin
-from ginga.canvas.types.astro import Annulus
 from ginga.gw.Widgets import SaveDialog
 from ginga.misc import Future, Widgets
 from ginga.qtw.QtHelp import QtGui
@@ -761,16 +760,18 @@ Click "Subtract" to remove background.""")
             s += ' ({0})'.format(self._debug_str)
         self.logger.info(s)
 
-        # Change data in Ginga object and recalculate BG in annulus
-        metadata = image.metadata
-        metadata['_latest_modification'] = s  # For ChangeHistory plugin
-        image.set_data(new_data, metadata=metadata)
+        # Change data in Ginga object and recalculate BG in annulus.
+        # This issues a 'modified' callback, which calls redo().
+        image.set_data(new_data, metadata=image.metadata)
         #self.fitsimage.auto_levels()
 
-        # Update file listing
         chname = self.fv.get_channelName(self.fitsimage)
         channel = self.fv.get_channelInfo(chname)
-        channel.image_data_modified(image)  # Also calls self.redo()
+
+        # Update file listing.
+        # This issues a 'image-modified' callback, which sets
+        # the timestamp and reason.
+        channel.image_data_modified(image, reason=s)
 
         return True
 

--- a/stginga/plugins/BackgroundSub.py
+++ b/stginga/plugins/BackgroundSub.py
@@ -19,7 +19,6 @@ from ginga.misc import Widgets
 from ginga.qtw.QtHelp import QtGui
 
 # LOCAL
-QUIP_LOG = None
 try:
     from stginga.utils import calc_stat
 except ImportError:
@@ -684,34 +683,14 @@ Click "Subtract" to remove background.""")
             s += ' ({0})'.format(self._debug_str)
         self.logger.info(s)
 
-        # Also record action in QUIP log, if available
-        if QUIP_LOG is not None:
-            imname = image.metadata['name'].split('[')[0]
-            s = QUIP_LOG.add_entry(imname, 'Background subtracted', s, 'status')
-
-        # Update history listing
-        try:
-            history_plugin_obj = self.fv.gpmon.getPlugin('History')
-        except Exception as e:
-            self.logger.debug(
-                'Failed to update History plugin: {0}'.format(str(e)))
-        else:
-            history_plugin_obj.add_entry(s)
-
         # Change data in Ginga object and recalculate BG in annulus
         image.set_data(new_data, metadata=image.metadata)
-        self.fitsimage.auto_levels()
-        self.redo()
+        #self.fitsimage.auto_levels()
 
         # Update file listing
-        try:
-            list_plugin_obj = self.fv.gpmon.getPlugin('ContentsManager')
-        except Exception as e:
-            self.logger.debug(
-                'Failed to update ContentsManager plugin: {0}'.format(str(e)))
-        else:
-            chname = self.fv.get_channelName(self.fitsimage)
-            list_plugin_obj.set_modified_status(chname, image, 'yes')
+        chname = self.fv.get_channelName(self.fitsimage)
+        channel = self.fv.get_channelInfo(chname)
+        channel.image_data_modified(image)  # Also calls self.redo()
 
         return True
 

--- a/stginga/plugins/BackgroundSub.py
+++ b/stginga/plugins/BackgroundSub.py
@@ -780,17 +780,17 @@ Click "Subtract" to remove background.""")
         self.logger.info(s)
 
         # Change data in Ginga object and recalculate BG in annulus.
-        # This issues a 'modified' callback, which calls redo().
+        # This issues a 'modified' callback, which sets timestamp and
+        # calls redo().
         image.set_data(new_data, metadata=image.metadata)
         #self.fitsimage.auto_levels()
 
         chname = self.fv.get_channelName(self.fitsimage)
         channel = self.fv.get_channelInfo(chname)
 
-        # Update file listing.
-        # This issues a 'image-modified' callback, which sets
-        # the timestamp and reason.
-        channel.image_data_modified(image, reason=s)
+        # Store change history in metadata
+        iminfo = channel.get_image_info(image.get('name'))
+        iminfo.reason_modified = s
 
         return True
 

--- a/stginga/plugins/ChangeHistory.py
+++ b/stginga/plugins/ChangeHistory.py
@@ -1,0 +1,188 @@
+"""ChangeHistory global plugin for Ginga."""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+# THIRD-PARTY
+from astropy.extern.six import iteritems
+
+# GINGA
+from ginga import GingaPlugin
+from ginga.gw import Widgets
+from ginga.misc import Bunch
+
+__all__ = []
+
+
+class ChangeHistory(GingaPlugin.GlobalPlugin):
+    """Keep track of buffer change history.
+
+    History should stay no matter what channel or image is active.
+    New history can be added, but old history cannot be deleted,
+    unless the image/channel itself is deleted.
+
+    """
+    def __init__(self, fv):
+        # superclass defines some variables for us, like logger
+        super(ChangeHistory, self).__init__(fv)
+
+        self.columns = [ ('Modification Timestamp', 'MODIFIED'),
+                         ('Description', 'DESCRIP'),
+                         ]
+        # For table-of-contents pane
+        self.name_dict = Bunch.caselessDict()
+        self.treeview = None
+
+        prefs = self.fv.get_preferences()
+        self.settings = prefs.createCategory('plugin_ChangeHistory')
+        self.settings.addDefaults(always_expand=True,
+                                  color_alternate_rows=True)
+        self.settings.load(onError='silent')
+
+        fv.add_callback('image-modified', self.image_modified_cb)
+        fv.add_callback('remove-image', self.remove_image_cb)
+        fv.add_callback('delete-channel', self.delete_channel_cb)
+
+        self.gui_up = False
+
+    def build_gui(self, container):
+        """This method is called when the plugin is invoked.  It builds the
+        GUI used by the plugin into the widget layout passed as
+        ``container``.
+
+        This method could be called several times if the plugin is opened
+        and closed.  The method may be omitted if there is no GUI for the
+        plugin.
+
+        """
+        top = Widgets.VBox()
+        top.set_border_width(4)
+
+        vbox, sw, self.orientation = Widgets.get_oriented_box(container)
+        vbox.set_border_width(4)
+        vbox.set_spacing(2)
+
+        # create the Treeview
+        always_expand = self.settings.get('always_expand', True)
+        color_alternate = self.settings.get('color_alternate_rows', True)
+        treeview = Widgets.TreeView(auto_expand=always_expand,
+                                    sortable=True,
+                                    use_alt_row_color=color_alternate)
+        self.treeview = treeview
+        treeview.setup_table(self.columns, 3, 'MODIFIED')
+        treeview.add_callback('selected', self.show_more)
+        vbox.add_widget(treeview, stretch=1)
+
+        fr = Widgets.Frame('Selected History')
+        captions = (('History Details', 'textarea'), )
+        w, b = Widgets.build_info(captions)
+        self.w.update(b)
+
+        b.history_details.set_editable(False)
+        b.history_details.set_wrap(True)
+        b.history_details.set_text('')
+        b.history_details.set_tooltip('Displays selected history entry')
+
+        fr.set_widget(w)
+        vbox.add_widget(fr, stretch=0)
+
+        top.add_widget(sw, stretch=1)
+        container.add_widget(top, stretch=1)
+
+        self.gui_up = True
+
+    def stop(self):
+        self.gui_up = False
+
+    def recreate_toc(self):
+        self.logger.debug("Recreating table of contents...")
+        self.treeview.set_tree(self.name_dict)
+
+    def show_more(self, widget, res_dict):
+        chname = list(res_dict.keys())[0]
+        img_dict = res_dict[chname]
+        imname = list(img_dict.keys())[0]
+        entries = img_dict[imname]
+        timestamp = list(entries.keys())[0]
+        bnch = entries[timestamp]
+        descrip = bnch.DESCRIP
+        msg = ('Channel: {0}\nImage: {1}\nTimestamp: {2}\n'
+               'Description:\n\n{3}'.format(chname, imname, timestamp, descrip))
+        self.w.history_details.set_text(msg)
+
+    def image_modified_cb(self, viewer, chname, image):
+        """Add an entry with image modification info.
+
+        .. code-block:: python
+
+            timestamp = image.get_header().get('MODIFIED', None)
+            descrip = image.metadata.get('_latest_modification', 'N/A')
+
+        """
+        imname = image.get('name', 'none')
+        timestamp = image.get_header().get('MODIFIED', None)
+
+        # Image fell out of cache and lost its history
+        if timestamp is None:
+            path = image.get('path')
+            self.remove_image_cb(viewer, chname, imname, path)
+            return
+
+        # TODO: A bit hacky, can this be improved?
+        descrip = image.metadata.get('_latest_modification', 'N/A')
+
+        # Add info to internal log
+        if chname not in self.name_dict:
+            self.name_dict[chname] = {}
+
+        fileDict = self.name_dict[chname]
+
+        if imname not in fileDict:
+            fileDict[imname] = {}
+
+        bnch = Bunch.Bunch(CHNAME=chname, NAME=imname, MODIFIED=timestamp,
+                           DESCRIP=descrip)
+        entries = fileDict[imname]
+
+        # timestamp is guaranteed to be unique?
+        entries[timestamp] = bnch
+
+        self.logger.debug("Added history for chname='{0}' imname='{1}' "
+                          "timestamp='{2}'".format(chname, imname, timestamp))
+
+        if self.gui_up:
+            self.recreate_toc()
+
+    def remove_image_cb(self, viewer, chname, name, path):
+        """Delete entries related to deleted image."""
+        if chname not in self.name_dict:
+            return
+
+        fileDict = self.name_dict[chname]
+
+        if name not in fileDict:
+            return
+
+        del fileDict[name]
+        self.logger.debug('{0} removed from ChangeHistory'.format(name))
+
+        if not self.gui_up:
+            return False
+        self.recreate_toc()
+
+    def delete_channel_cb(self, viewer, chinfo):
+        """Called when a channel is deleted from the main interface.
+        Parameter is chinfo (a bunch)."""
+        chname = chinfo.name
+        del self.name_dict[chname]
+        self.logger.debug('{0} removed from ChangeHistory'.format(chname))
+
+        if not self.gui_up:
+            return False
+        self.recreate_toc()
+
+    def clear(self):
+        self.name_dict = Bunch.caselessDict()
+        self.recreate_toc()
+
+    def __str__(self):
+        return 'changehistory'

--- a/stginga/plugins/DQInspect.py
+++ b/stginga/plugins/DQInspect.py
@@ -123,7 +123,7 @@ class DQInspect(GingaPlugin.LocalPlugin):
         # TODO: Need to test this when we have a plugin that modifies DQ.
         # Overrides redo() issued by image.set_data() by recalculating.
         fv.add_callback(
-            'image-modified', lambda *args: self.redo(ignore_image_cache=True))
+            'add-image-info', lambda *args: self.redo(ignore_image_cache=True))
 
         fv.add_callback('remove-image', lambda *args: self.redo())
 

--- a/stginga/utils.py
+++ b/stginga/utils.py
@@ -69,18 +69,3 @@ def calc_stat(data, sigma=1.8, niter=10, algorithm='median'):
                          'calculations'.format(algorithm))
 
     return val
-
-
-# -------------- #
-# FITS FUNCTIONS #
-# -------------- #
-
-def _fits_extnamever_lookup(filename, extname, extver):
-    """Return ext num for given name and ver."""
-    extnum = -1
-    with fits.open(filename) as pf:
-        for i, hdu in enumerate(pf):
-            if hdu.name.startswith(extname) and hdu.ver == extver:
-                extnum = i
-                break
-    return extnum


### PR DESCRIPTION
Removed QUIP specific codes. Disabled image `auto_levels()`; don't think it is necessary. `sub_bg()` now uses `image-modified` callback (see ejeschke/ginga#223 and ejeschke/ginga#215). Added capability to exclude bad pixels from calculations.

This fixes #43.

Also fixes #38.

Also fixes #35.
