### PR TITLE
Fixes for upstream changes to colorbar and readout handling

### DIFF
--- a/stginga/gingawrapper.py
+++ b/stginga/gingawrapper.py
@@ -44,6 +44,18 @@ gmain.default_layout = ['seq', {}, [
                                'group': 1}
                     ],
                      'stretch': 1
+                    },
+                    {'row': [
+                        'ws', {'wstype': 'stack', 'name': 'cbar',
+                               'group': 99}
+                    ],
+                     'stretch': 0
+                    },
+                    {'row': [
+                        'ws', {'wstype': 'stack', 'name': 'readout',
+                               'group': 99}
+                    ],
+                     'stretch': 0
                     }
                 ],
                 [


### PR DESCRIPTION
This fixes the layout of stginga to handle changes in the way the color bar and readout are handled upstream.  You now have more flexibility if you want to lay them out differently or customize further.
