### PR TITLE
Expose new toolbar in Ginga reference viewer

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ norecursedirs = build docs/_build
 [ah_bootstrap]
 auto_use = True
 
-[pep8]
+[pycodestyle]
 exclude = extern,sphinx
 
 [metadata]

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ import glob
 import os
 import sys
 
-import ah_bootstrap
+import ah_bootstrap  # noqa
 from setuptools import setup
 
-#A dirty hack to get around some early import/configurations ambiguities
+# A dirty hack to get around some early import/configurations ambiguities
 if sys.version_info[0] >= 3:
     import builtins
 else:
@@ -58,10 +58,6 @@ if not RELEASE:
 # invoking any other functionality from distutils since it can potentially
 # modify distutils' behavior.
 cmdclassd = register_commands(PACKAGENAME, VERSION, RELEASE)
-
-# Adjust the compiler in case the default on this platform is to use a
-# broken one.
-#adjust_compiler(PACKAGENAME)
 
 # Freeze build information in version.py
 generate_version_py(PACKAGENAME, VERSION, RELEASE,
@@ -121,4 +117,4 @@ setup(name=PACKAGENAME,
       use_2to3=True,
       entry_points=entry_points,
       **package_info
-)
+      )

--- a/stginga/_astropy_init.py
+++ b/stginga/_astropy_init.py
@@ -113,6 +113,7 @@ def test(package=None, test_path=None, args=None, plugins=None,
         remote_data=remote_data, pep8=pep8, pdb=pdb,
         coverage=coverage, open_files=open_files, **kwargs)
 
+
 if not _ASTROPY_SETUP_:
     import os
     from warnings import warn

--- a/stginga/gingawrapper.py
+++ b/stginga/gingawrapper.py
@@ -6,7 +6,6 @@ import sys
 
 # GINGA
 from ginga import main as gmain
-from ginga.misc.Bunch import Bunch
 
 # Suppress logging "no handlers" message from Ginga
 import logging
@@ -40,7 +39,7 @@ gmain.default_layout = ['seq', {}, [
                     'vbox', {'name': 'main', 'width': 700},
                     {'row': [
                         'ws', {'wstype': 'tabs', 'name': 'channels',
-                               'group': 1}
+                               'group': 1, 'use_toolbar': True}
                     ],
                      'stretch': 1
                     },


### PR DESCRIPTION
Expose new toolbar in Ginga reference viewer. This is a response to ejeschke/ginga#377. When this toolbar also exists in `stginga`'s layout, it enables the option for Ginga developer to remove the duplicate icons from the bottom (older) toolbar.