### PR TITLE
Replace cfg mention of circular with circle

### DIFF
--- a/stginga/examples/configs/plugin_BadPixCorr.cfg
+++ b/stginga/examples/configs/plugin_BadPixCorr.cfg
@@ -10,8 +10,8 @@ bpixcorrcolor = 'green'
 bpixannuluscolor = 'magenta'
 
 # Default bad pixel(s) properties. Some can also be changed in the GUI.
-# corrtype can be 'single' or 'circular'
-corrtype = 'circular'
+# corrtype can be 'single' or 'circle'
+corrtype = 'circle'
 point_radius = 5
 
 # Default correction parameters. Can also be changed in the GUI.

--- a/stginga/examples/configs/plugin_SNRCalc.cfg
+++ b/stginga/examples/configs/plugin_SNRCalc.cfg
@@ -10,8 +10,8 @@ sbrcolor = 'blue3'
 sbrbgcolor = 'magenta'
 
 # Signal calculation parameters. Can also be changed in the GUI.
-# sigtype can be 'box', 'circular', or 'polygon'
-sigtype = 'circular'
+# sigtype can be 'box', 'circle', or 'polygon'
+sigtype = 'circle'
 
 # Background calculation parameters. Can also be changed in the GUI.
 bgradius = 200


### PR DESCRIPTION
Not sure how this went unnoticed for so long. Anyone who try to use these configs will run into error loading the affected plugins. Ops! (Most people, i.e., me, probably don't copy these over much...)