### PR TITLE
Compat with Ginga PR 764, RTD PR build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,23 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+# Set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  system_packages: true
+  install:
+    - requirements: docs/rtd-pip-requirements
+    - method: setuptools
+      path: .
+
+submodules:
+  include: all
+
+# Don't build any extra formats
+formats: []

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,11 +54,6 @@ env:
 matrix:
     include:
 
-        # Check for sphinx doc build warnings - we do this first because it
-        # may run for a long time
-        - os: linux
-          env: PYTHON_VERSION=3.6 SETUP_CMD='build_docs -w' PIP_DEPENDENCIES='sphinx-astropy'
-
         # DISABLED FOR NOW
         # Do a coverage test.
         #- os: linux

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -154,4 +154,4 @@ man_pages = [('index', project.lower(), project + u' Documentation',
 # -- Options for intersphinx ---------------------------------------------------
 
 intersphinx_mapping.update({
-        'ginga': ('http://ginga.readthedocs.org/en/latest/', None)})
+        'ginga': ('https://ginga.readthedocs.io/en/latest/', None)})

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,7 @@ except ImportError:
             sys.path.insert(1, a_h_path)
 
 # Load all of the global Astropy configuration
-from astropy_helpers.sphinx.conf import *
+from sphinx_astropy.conf.v1 import *
 
 # Get configuration information from setup.cfg
 from configparser import ConfigParser

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,6 +1,5 @@
 numpy>=1.13
 scipy>=0.18
 sphinx-astropy
-astropy-helpers
 astropy>=3
 ginga>=2.7

--- a/experimental/notebooks/astrowidgets_asdf_in_fits.ipynb
+++ b/experimental/notebooks/astrowidgets_asdf_in_fits.ipynb
@@ -6,17 +6,17 @@
    "source": [
     "# Reading JWST ASDF-in-FITS with `astrowidgets`\n",
     "\n",
-    "This is a proof-of-concept using `astrowidgets` to read in JWST ASDF-in-FITS data. As it is using the dev versions of several different packages, this notebook is not guaranteed to work as-is in the future.\n",
+    "This is a proof-of-concept using `astrowidgets` to read in JWST ASDF-in-FITS data. As it is using the dev versions of several different packages, this notebook is not guaranteed to work as-is in the future. As Ginga is primarily an image viewer, we will not concern ourselves with spectrocopic data models in this notebook.\n",
     "\n",
-    "Relevant specs used in testing:\n",
+    "Relevant specs used in testing (more or less):\n",
     "\n",
     "* Python 3.7.3\n",
     "* `aggdraw` 1.3.11\n",
-    "* `asdf` 2.4.0.dev61+g341ec87\n",
-    "* `astropy` 4.0.dev25456\n",
-    "* `astrowidgets` 0.1.0.dev132\n",
-    "* `ginga` 3.0.dev2197 (https://github.com/ejeschke/ginga/pull/781)\n",
-    "* `gwcs` 0.12.dev535\n",
+    "* `asdf` 2.4.0.dev\n",
+    "* `astropy` 4.0.dev\n",
+    "* `astrowidgets` 0.1.0.dev\n",
+    "* `ginga` 3.0.dev (https://github.com/ejeschke/ginga/pull/781 and https://github.com/ejeschke/ginga/pull/764)\n",
+    "* `gwcs` 0.12.dev\n",
     "* `ipyevents` 0.6.2\n",
     "* `ipywidgets` 7.5.0\n",
     "* `jsonschema` 2.6.0\n",
@@ -24,12 +24,12 @@
     "* `jupyter_client` 5.3.1\n",
     "* `jupyter_console` 6.0.0\n",
     "* `jupyter_core` 4.5.0\n",
-    "* `jwst` 0.13.8a0.dev131+g9a260957\n",
+    "* `jwst` 0.13.8a0.dev\n",
     "* `notebook` 6.0.0\n",
     "* `numpy` 1.16.4\n",
     "* `opencv` 3.4.2\n",
     "* `scipy` 1.3.0\n",
-    "* `stginga` 1.1.dev308 (https://github.com/spacetelescope/stginga/pull/177)"
+    "* `stginga` 1.1.dev308 (https://github.com/spacetelescope/stginga/pull/177 and https://github.com/spacetelescope/stginga/pull/179)"
    ]
   },
   {
@@ -44,11 +44,8 @@
     "\n",
     "from astrowidgets import ImageWidget\n",
     "\n",
-    "from ginga.AstroImage import AstroImage\n",
     "from ginga.misc.log import get_logger\n",
-    "from ginga.util import wcsmod\n",
-    "\n",
-    "from stginga.utils import JWSTASDFHandler"
+    "from ginga.util import wcsmod"
    ]
   },
   {
@@ -115,22 +112,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We register our custom file handler (`JWSTASDFHandler`) with Ginga's `AstroImage` class. As Ginga is primarily an image viewer, we will not concern ourselves with spectrocopic data models in this notebook."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "AstroImage.set_ioClass(JWSTASDFHandler)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Then, we customize our image widget by subclassing `ImageWidget` and adding a method to load the file. In the future, after https://github.com/astropy/astrowidgets/pull/78 is merged, this subclassing will be unnecessary and we will be able to use `ImageWidget` directly."
    ]
   },
@@ -142,8 +123,11 @@
    "source": [
     "class JWSTImageWidget(ImageWidget):  \n",
     "    def load_file(self, filename):\n",
-    "        image = AstroImage(logger=self.logger)\n",
-    "        image.load_file(filename)\n",
+    "        from ginga.util.io import io_asdf\n",
+    "        \n",
+    "        # Even if jwst package is not called directly, it is used\n",
+    "        # to load the correct GWCS data models behind the scenes.\n",
+    "        image = io_asdf.load_file(filename)\n",
     "        self._viewer.set_image(image)"
    ]
   },

--- a/stginga/plugins/MosaicAuto.py
+++ b/stginga/plugins/MosaicAuto.py
@@ -37,13 +37,13 @@ from astropy.io import ascii
 from astropy.wcs import WCS
 
 # GINGA
-from ginga.AstroImage import AstroImage
 from ginga.gw import Widgets
 from ginga.misc import Bunch
 from ginga.rv.plugins.Mosaic import Mosaic
 
 # STGINGA
 from stginga.plugins.local_plugin_mixin import HelpMixin
+from stginga.utils import GINGA_LT_3
 
 __all__ = ['MosaicAuto']
 
@@ -158,7 +158,12 @@ class MosaicAuto(HelpMixin, Mosaic):
 
     def auto_mosaic(self):
         """Create new mosaic using image list from Contents."""
-        astroimage_obj = AstroImage()
+        if GINGA_LT_3:
+            from ginga.AstroImage import AstroImage
+            astroimage_obj = AstroImage()
+        else:
+            from ginga.util.io_fits import load_file
+
         self._imlist = {}
         self._recreate_fp = True
         self.treeview.clear()
@@ -178,9 +183,11 @@ class MosaicAuto(HelpMixin, Mosaic):
             datasrc = self.chinfo.datasrc
             if imname in datasrc:
                 image = datasrc[imname]
-            else:
+            elif GINGA_LT_3:
                 image = astroimage_obj
                 image.load_file(impath)
+            else:
+                image = load_file(impath)
             footprint = image.wcs.wcs.calc_footprint()  # Astropy only?
             self._imlist[imname] = Bunch.Bunch(
                 footprint=footprint, path=impath)

--- a/stginga/utils.py
+++ b/stginga/utils.py
@@ -14,57 +14,11 @@ from astropy.utils.exceptions import AstropyUserWarning
 from scipy.interpolate import griddata
 from scipy.ndimage.interpolation import zoom
 
-try:
-    from ginga.util.io_asdf import ASDFFileHandler
-except ImportError:
-    HAS_ASDFHANDLER = False
-    class ASDFFileHandler:  # noqa
-        pass
-else:
-    HAS_ASDFHANDLER = True
-
-try:
-    from jwst import datamodels
-except ImportError:
-    datamodels = None
-
 ASTROPY_LT_3_1 = not minversion('astropy', '3.1')
+GINGA_LT_3 = not minversion('ginga', '3.0')
 
-__all__ = ['JWSTASDFHandler', 'calc_stat', 'interpolate_badpix', 'find_ext',
-           'DQParser', 'scale_image']
-
-
-class JWSTASDFHandler(ASDFFileHandler):
-    """Class to handle JWST ASDF-in-FITS files.
-
-    .. warning:: This is experimental and subject to change.
-
-    .. note:: This requires Ginga 3.0 (unreleased as of July 2019) or later.
-              This also requires dev version of ``jwst`` pipeline.
-
-    """
-    factory_dict = {}
-
-    def __init__(self, *args, **kwargs):
-        if not HAS_ASDFHANDLER or datamodels is None:
-            raise ImportError('Requires Ginga>=3.0 and jwst')
-
-        super().__init__(*args, **kwargs)
-
-    @classmethod
-    def register_type(cls, name, klass):
-        cls.factory_dict[name.lower()] = klass
-
-    def load_file(self, filespec, dstobj=None, **kwdargs):
-        with datamodels.open(filespec) as dm:
-            dstobj.setup_data(dm.data)
-            dstobj.wcs.wcs = dm.meta.wcs  # Not dm.wcs!
-            dstobj.wcs.coordsys = dm.meta.wcs.output_frame.name
-
-        return dstobj
-
-    def save_as_file(self, path, data, header, **kwdargs):
-        raise NotImplementedError
+__all__ = ['calc_stat', 'interpolate_badpix', 'find_ext', 'DQParser',
+           'scale_image']
 
 
 def calc_stat(data, sigma=1.8, niter=10, algorithm='median'):


### PR DESCRIPTION
This patch is to be compatible with a new way of handling different file I/O in Ginga PR ejeschke/ginga#764 . ~This cannot be merged until Ginga 3.0 is out.~

**TODO**

- [x] Handle compatibility between Ginga 2 and 3 gracefully.
- [x] Make sure tests run and pass.