### PR TITLE
Multiline config value for DQInspect (Ginga 3.2)

### DIFF
--- a/stginga/examples/configs/plugin_DQInspect.cfg
+++ b/stginga/examples/configs/plugin_DQInspect.cfg
@@ -6,8 +6,22 @@
 # Display long or short descriptions
 dqstr = 'long'
 
-# DQ definition files
-dqdict = {'JWST': {'FGS': 'data/dqflags_jwst.txt', 'MIRI': 'data/dqflags_jwst.txt', 'NIRCAM': 'data/dqflags_jwst.txt', 'NIRISS': 'data/dqflags_jwst.txt', 'NIRSPEC': 'data/dqflags_jwst.txt'}, 'HST': {'ACS': 'data/dqflags_acs.txt', 'COS': 'data/dqflags_hstgen.txt', 'FGS': 'data/dqflags_hstgen.txt', 'STIS': 'data/dqflags_hstgen.txt', 'WFC3': 'data/dqflags_wfc3.txt', 'WFPC2': 'data/dqflags_hstgen.txt'}}
+# DQ definition files.
+# NOTE: Multiline config value requires Ginga 3.1 or later.
+#       For older Ginga, this needs to be all in one line.
+dqdict = {
+    'JWST': {
+        'FGS': 'data/dqflags_jwst.txt',
+        'MIRI': 'data/dqflags_jwst.txt',
+        'NIRCAM': 'data/dqflags_jwst.txt',
+        'NIRISS': 'data/dqflags_jwst.txt',
+        'NIRSPEC': 'data/dqflags_jwst.txt'},
+    'HST': {'ACS': 'data/dqflags_acs.txt',
+        'COS': 'data/dqflags_hstgen.txt',
+        'FGS': 'data/dqflags_hstgen.txt',
+        'STIS': 'data/dqflags_hstgen.txt',
+        'WFC3': 'data/dqflags_wfc3.txt',
+        'WFPC2': 'data/dqflags_hstgen.txt'}}
 
 # Color to mark a single pixel for inspection
 pxdqcolor = 'red'


### PR DESCRIPTION
Multiline cfg support from ejeschke/ginga#862 . This won't be possible unless you are using Ginga 3.2 (release TBD) or later.

Should be no functionality change but the file will be more human-readable.