### PR TITLE
MNT: Remove unused astropy config code

### DIFF
--- a/stginga/_astropy_init.py
+++ b/stginga/_astropy_init.py
@@ -1,10 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
-from warnings import warn
 
-from astropy import config
-from astropy.config.configuration import (
-    ConfigurationDefaultMissingError, ConfigurationDefaultMissingWarning)
 from astropy.tests.runner import TestRunner
 
 try:
@@ -18,26 +14,3 @@ test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
 test.__test__ = False
 
 __all__ = ['__version__', 'test']
-
-# add these here so we only need to cleanup the namespace at the end
-config_dir = None
-
-if not os.environ.get('ASTROPY_SKIP_CONFIG_UPDATE', False):
-    config_dir = os.path.dirname(__file__)
-    config_template = os.path.join(config_dir, __package__ + ".cfg")
-    if os.path.isfile(config_template):
-        try:
-            config.configuration.update_default_config(
-                __package__, config_dir, version=__version__)
-        except TypeError as orig_error:
-            try:
-                config.configuration.update_default_config(
-                    __package__, config_dir)
-            except ConfigurationDefaultMissingError as e:
-                wmsg = (e.args[0] + " Cannot install default profile. "
-                        "If you are "
-                        "importing from source, this is expected.")
-                warn(ConfigurationDefaultMissingWarning(wmsg))
-                del e
-            except Exception:
-                raise orig_error


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/stginga/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This is probably leftover from package template. This package does not use the `astropy` configuration system at all.

Also see astropy/astropy#11497