### PR TITLE
MNT: Replace deprecated dtypes in numpy 1.21

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,9 @@ testpaths = "stginga" "docs"
 norecursedirs = build docs/_build
 astropy_header = true
 filterwarnings =
-    ignore:numpy.ufunc size changed
+    error
+    ignore:numpy.ufunc size changed:RuntimeWarning
+    ignore:numpy.ndarray size changed:RuntimeWarning
 
 [metadata]
 name = stginga

--- a/stginga/plugins/BadPixCorr.py
+++ b/stginga/plugins/BadPixCorr.py
@@ -806,7 +806,7 @@ class BadPixCorr(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
             mask = image.get_shape_mask(bpx_obj)
             s += f'x={self.xcen}, y={self.ycen}, r={self.radius}'
         else:  # single pixel
-            mask = np.zeros(data.shape, dtype=np.bool)
+            mask = np.zeros(data.shape, dtype=bool)
             xx = int(self.xcen)
             yy = int(self.ycen)
             mask[yy, xx] = True

--- a/stginga/plugins/DQInspect.py
+++ b/stginga/plugins/DQInspect.py
@@ -468,7 +468,7 @@ class DQInspect(HelpMixin, LocalPlugin, MEFMixin):
         # To save memory, composite mask is generated on the fly.
         imdqcolors = self.settings.get('imdqcolors', self._def_imdqcolors)
         n_color = len(imdqcolors)
-        mask = np.zeros(self._curshape, dtype=np.bool)
+        mask = np.zeros(self._curshape, dtype=bool)
         m_objs = []
 
         # Evenly distribute alpha between all individual masks
@@ -483,7 +483,7 @@ class DQInspect(HelpMixin, LocalPlugin, MEFMixin):
 
             # Mask only for that DQ flag, for individual color display
             cur_col = imdqcolors[i % n_color]
-            cur_mask = np.zeros(self._curshape, dtype=np.bool)
+            cur_mask = np.zeros(self._curshape, dtype=bool)
             cur_mask[self._curpxmask[ikey]] = True
             m_objs.append(self.dc.Image(
                 0, 0, masktorgb(cur_mask, color=cur_col, alpha=imdqalpha)))

--- a/stginga/tests/test_utils.py
+++ b/stginga/tests/test_utils.py
@@ -40,7 +40,7 @@ class TestInterpBadPix(object):
     def setup_class(self):
         self.image = np.array([[1, 2, 3],
                                [4, 0, 6],
-                               [7, 8, 9]], dtype=np.float)
+                               [7, 8, 9]], dtype=float)
         self.basis_mask = np.array([[True, True, True],
                                     [True, False, True],
                                     [True, True, True]])

--- a/stginga/utils.py
+++ b/stginga/utils.py
@@ -193,8 +193,8 @@ class DQParser(object):
             os.path.expanduser(definition_file),
             names=(self._dqcol, self._sdcol, self._ldcol),
             converters={self._dqcol: [ascii.convert_numpy(np.uint)],
-                        self._sdcol: [ascii.convert_numpy(np.str)],
-                        self._ldcol: [ascii.convert_numpy(np.str)]})
+                        self._sdcol: [ascii.convert_numpy(str)],
+                        self._ldcol: [ascii.convert_numpy(str)]})
 
         # Another table to store metadata
         self.metadata = ascii.read(self.tab.meta['comments'], delimiter='=',
@@ -231,7 +231,7 @@ class DQParser(object):
             of affected array elements.
 
         """
-        data = np.asarray(data, dtype=np.int)  # Ensure int array
+        data = np.asarray(data, dtype=int)  # Ensure int array
         dqs_by_flag = {}
 
         def _one_flag(vf):
@@ -506,10 +506,10 @@ def scale_image_with_dq(infile, outfile, zoom_factor, dq_parser,
     # Edge pixels
     iy_max = data.shape[0] - ignore_edge_pixels
     ix_max = data.shape[1] - ignore_edge_pixels
-    edge_mask = np.ones_like(dq, dtype=np.bool)
+    edge_mask = np.ones_like(dq, dtype=bool)
     edge_mask[ignore_edge_pixels:iy_max, ignore_edge_pixels:ix_max] = False
 
-    badpix_mask = np.zeros_like(dq, dtype=np.bool)
+    badpix_mask = np.zeros_like(dq, dtype=bool)
     badpix_mask[dqs_by_flags[bad_flag]] = True
     badpix_mask[edge_mask] = False  # Ignore edge
 


### PR DESCRIPTION
MNT: Replace deprecated dtypes

TST: Turn all warnings into errors.

Fix #218 