### PR TITLE
Force drawn circle to have a minimum radius of 1 px

### DIFF
--- a/stginga/plugins/BadPixCorr.py
+++ b/stginga/plugins/BadPixCorr.py
@@ -356,7 +356,9 @@ class BadPixCorr(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
         obj.linestyle = 'solid'
 
         if obj.kind == 'circle':
-            self.radius = obj.radius
+            # force a radius of at least 1 pixel
+            self.radius = max(obj.radius, 1.0)
+            obj.radius = self.radius
             yt = y + self.radius + self._text_label_offset
         else:  # point
             obj.radius = self._point_radius

--- a/stginga/plugins/BadPixCorr.py
+++ b/stginga/plugins/BadPixCorr.py
@@ -84,7 +84,7 @@ class BadPixCorr(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
 
         # Used for calculation
         self.xcen, self.ycen = self._dummy_value, self._dummy_value
-        self.radius = self._dummy_value
+        self.radius = 1  # Avoid zero-radius circle
 
         # Stores latest result
         self.fillval = self._dummy_value


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/stginga/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

Forces a click when drawing a circle in BadPixCorr plugin to have a radius  of 1px minimum

<!-- In addition please ensure that the pull request title is descriptive. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #227