### PR TITLE
remove unsupported `system_packages` RTD config setting

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install and build
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install -U numpy --pre
+        python -m pip install -U numpy pyerfa astropy-iers-data PyYAML packaging
         python -m pip install -U -i https://pypi.anaconda.org/astropy/simple astropy --pre
         python -m pip install git+https://github.com/ejeschke/ginga.git@main#egg=ginga
         python -m pip install -e .[test]

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -95,6 +95,7 @@ jobs:
     - name: Install and build
       run: |
         python -m pip install --upgrade pip setuptools wheel
+        python -m pip install -U numpy --pre
         python -m pip install -U -i https://pypi.anaconda.org/astropy/simple astropy --pre
         python -m pip install git+https://github.com/ejeschke/ginga.git@main#egg=ginga
         python -m pip install -e .[test]

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -95,8 +95,8 @@ jobs:
     - name: Install and build
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install git+https://github.com/astropy/astropy.git@main#egg=astropy
-        python -m pip install git+https://github.com/ejeschke/ginga.git@master#egg=ginga
+        python -m pip install -U -i https://pypi.anaconda.org/astropy/simple astropy --pre
+        python -m pip install git+https://github.com/ejeschke/ginga.git@main#egg=ginga
         python -m pip install -e .[test]
     - name: Test with dev deps
       run: pytest

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,6 @@ sphinx:
 
 # Set the version of Python and requirements required to build your docs
 python:
-  system_packages: false
   install:
     - method: pip
       path: .

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ zip_safe = False
 setup_requires =
     setuptools_scm
 install_requires =
+    numpy
     astropy>=3
     ginga>=2.7
     scipy>=0.18
@@ -46,11 +47,7 @@ python_requires = >=3.7
 test =
     pytest-astropy
 docs =
-    numpy
-    scipy
     sphinx-astropy
-    astropy
-    ginga
 
 [options.package_data]
 stginga = data/*, examples/*/*


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/stginga/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

RTD no longer supports any `system_packages` setting: https://blog.readthedocs.com/drop-support-system-packages/

This PR removes the unused `system_packages` setting

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

