### PR TITLE
Obviate need to start plugins in user's ginga_config.py

### DIFF
--- a/stginga/gingawrapper.py
+++ b/stginga/gingawrapper.py
@@ -36,7 +36,7 @@ def run_stginga(sys_argv):
     # Note: Unable to get this to work from within ginga_config.py
     # Example:
     #     glb_plg_to_remove = ['WBrowser', 'RC', 'SAMP', 'IRAF']
-    plg_to_remove = []
+    plg_to_remove = ['PluginConfig']
     _remove_plugins(plg_to_remove, gmain.plugins)
 
     # Add custom plugins.
@@ -51,9 +51,11 @@ def run_stginga(sys_argv):
     #     new_argv[new_argv.index('-t') + 1] = 'qt'
 
     # Auto start core global plugins
-    for gplgname in ('ChangeHistory', ):
+    for gplgname in ('ChangeHistory', 'Zoom', 'Header'):
         gplg = _locate_plugin(gmain.plugins, gplgname)
         gplg.start = True
+        # prevents appearing in the Operations plugin tray
+        gplg.optray = False
 
     # Start Ginga
     gmain.reference_viewer(sys_argv)
@@ -73,7 +75,8 @@ def _remove_plugins(rmlist, plist):
     """Remove default global or local plugin(s) from Ginga."""
     for plgname in rmlist:
         plg = _locate_plugin(plist, plgname)
-        plist.remove(plg)
+        if plg is not None:
+            plist.remove(plg)
 
 
 # This is used by entry point.


### PR DESCRIPTION
- change gingawrapper to set autostart for plugins previously started in custom ginga_config.py
- make them not appear in the optray
- disable the PluginConfig from ginga v5

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/stginga/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request changes the stginga wrapper to auto start the `Zoom` and `Header` plugins, which previously were auto started by writing a custom `ginga_config.py`.  Furthermore, this hides them when in the Operations tray, so that they appear more like other "required" plugins. Finally, this disables the upcoming `PluginConfig` plugin in Ginga v5, so that `stginga` users cannot customize their plugins, except in the old way of modifying `general.cfg` or with a `ginga_config.py`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

