### PR TITLE
Fix for Ginga upstream deprecation

### DIFF
--- a/stginga/plugins/BackgroundSub.py
+++ b/stginga/plugins/BackgroundSub.py
@@ -306,7 +306,7 @@ class BackgroundSub(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
         self.xcen = data_x
         self.ycen = data_y
 
-        bg_obj.move_to(data_x, data_y)
+        bg_obj.move_to_pt((data_x, data_y))
         tag = canvas.add(bg_obj)
         self.draw_cb(canvas, tag)
         return True
@@ -325,7 +325,7 @@ class BackgroundSub(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
         if bg_obj.kind not in ('compound', 'annulus', 'rectangle'):
             return True
 
-        bg_obj.move_to(data_x, data_y)
+        bg_obj.move_to_pt((data_x, data_y))
 
         if obj.kind == 'compound':
             try:
@@ -522,7 +522,7 @@ class BackgroundSub(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
                 y = c_obj.y
             else:
                 y = c_obj.get_center_pt()[1]
-            c_obj.move_to(self.xcen, y)
+            c_obj.move_to_pt((self.xcen, y))
 
         self.fitsimage.redraw(whence=3)
         return self.redo()
@@ -552,7 +552,7 @@ class BackgroundSub(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
             y2 = self.ycen + 0.5 * self.boxheight
 
         # Reposition background region
-        bg_obj.move_to(x, self.ycen)
+        bg_obj.move_to_pt((x, self.ycen))
 
         # Reposition label to match
         obj.objects[1].y = y2 + self._text_label_offset

--- a/stginga/plugins/BadPixCorr.py
+++ b/stginga/plugins/BadPixCorr.py
@@ -303,7 +303,7 @@ class BadPixCorr(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
         self.xcen = data_x
         self.ycen = data_y
 
-        bpx_obj.move_to(data_x, data_y)
+        bpx_obj.move_to_pt((data_x, data_y))
         tag = canvas.add(bpx_obj)
         self.draw_cb(canvas, tag)
         return True
@@ -322,7 +322,7 @@ class BadPixCorr(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
         if bpx_obj.kind not in ('circle', 'point'):
             return True
 
-        bpx_obj.move_to(data_x, data_y)
+        bpx_obj.move_to_pt((data_x, data_y))
 
         if obj.kind == 'compound':
             try:
@@ -349,7 +349,7 @@ class BadPixCorr(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
 
         # Round to nearest pixel
         x, y = round(obj.x), round(obj.y)
-        obj.move_to(x, y)
+        obj.move_to_pt((x, y))
 
         # Change bad pix region appearance
         obj.color = self.bpixcorrcolor
@@ -607,7 +607,7 @@ class BadPixCorr(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
                 y = c_obj.y
             else:
                 y = c_obj.get_center_pt()[1]
-            c_obj.move_to(self.xcen, y)
+            c_obj.move_to_pt((self.xcen, y))
 
         self.fitsimage.redraw(whence=3)
         return self.redo()
@@ -638,7 +638,7 @@ class BadPixCorr(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
         if n_obj == 3:
             # Also reposition annulus
             ann_obj = obj.objects[1]
-            ann_obj.move_to(ann_obj.x, self.ycen)
+            ann_obj.move_to_pt((ann_obj.x, self.ycen))
             c_obj.y = (self.ycen + ann_obj.radius + ann_obj.width +
                        self._text_label_offset)
         elif bpx_obj.kind == 'circle':  # circle without annulus

--- a/stginga/plugins/DQInspect.py
+++ b/stginga/plugins/DQInspect.py
@@ -533,7 +533,7 @@ class DQInspect(HelpMixin, LocalPlugin, MEFMixin):
         self.xcen = data_x
         self.ycen = data_y
 
-        pix_obj.move_to(data_x, data_y)
+        pix_obj.move_to_pt((data_x, data_y))
         tag = canvas.add(pix_obj)
         self.draw_cb(canvas, tag)
         return True
@@ -555,7 +555,7 @@ class DQInspect(HelpMixin, LocalPlugin, MEFMixin):
         if pix_obj.kind != 'point':
             return True
 
-        pix_obj.move_to(data_x, data_y)
+        pix_obj.move_to_pt((data_x, data_y))
 
         if obj.kind == 'compound':
             try:
@@ -582,7 +582,7 @@ class DQInspect(HelpMixin, LocalPlugin, MEFMixin):
 
         # Round to nearest pixel
         x, y = round(obj.x), round(obj.y)
-        obj.move_to(x, y)
+        obj.move_to_pt((x, y))
 
         # Change bad pix region appearance
         obj.radius = self._point_radius
@@ -627,7 +627,7 @@ class DQInspect(HelpMixin, LocalPlugin, MEFMixin):
         # Reposition all elements to match
         for c_obj in obj.objects:
             if c_obj.kind != 'image':
-                c_obj.move_to(self.xcen, c_obj.y)
+                c_obj.move_to_pt((self.xcen, c_obj.y))
 
         self.fitsimage.redraw(whence=3)
         return self.redo()

--- a/stginga/plugins/SNRCalc.py
+++ b/stginga/plugins/SNRCalc.py
@@ -514,7 +514,7 @@ class SNRCalc(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
         self.xcen = data_x
         self.ycen = data_y
 
-        sig_obj.move_to(data_x, data_y)
+        sig_obj.move_to_pt((data_x, data_y))
         tag = canvas.add(sig_obj)
         self.draw_cb(canvas, tag)
         return True
@@ -533,7 +533,7 @@ class SNRCalc(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
         if sig_obj.kind not in ('circle', 'polygon', 'rectangle'):
             return True
 
-        sig_obj.move_to(data_x, data_y)
+        sig_obj.move_to_pt((data_x, data_y))
 
         if obj.kind == 'compound':
             try:
@@ -691,12 +691,12 @@ class SNRCalc(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
         self.w.bg_y.set_text(str(self.bgycen))
 
         # Reposition annulus
-        obj.objects[1].move_to(self.bgxcen, self.bgycen)
+        obj.objects[1].move_to_pt((self.bgxcen, self.bgycen))
 
         # Reposition label
         yt = (self.bgycen + self.bgradius + self.annulus_width +
               self._text_label_offset)
-        obj.objects[2].move_to(self.bgxcen, yt)
+        obj.objects[2].move_to_pt((self.bgxcen, yt))
 
         self.fitsimage.redraw(whence=3)
         return self.redo()
@@ -723,7 +723,7 @@ class SNRCalc(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
 
         else:  # polygon, rectangle
             y = sig_obj.get_center_pt()[1]
-            sig_obj.move_to(self.xcen, y)
+            sig_obj.move_to_pt((self.xcen, y))
 
         self.fitsimage.redraw(whence=3)
         return self.redo()
@@ -750,7 +750,7 @@ class SNRCalc(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
 
         else:  # polygon, rectangle
             x = sig_obj.get_center_pt()[0]
-            sig_obj.move_to(x, self.ycen)
+            sig_obj.move_to_pt((x, self.ycen))
 
         self.fitsimage.redraw(whence=3)
         return self.redo()
@@ -852,7 +852,7 @@ class SNRCalc(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
         # Reposition annulus and label
         for i in (1, 2):
             cobj = obj.objects[i]
-            cobj.move_to(self.bgxcen, cobj.y)
+            cobj.move_to_pt((self.bgxcen, cobj.y))
 
         self.fitsimage.redraw(whence=3)
         return self.redo()
@@ -874,7 +874,7 @@ class SNRCalc(HelpMixin, LocalPlugin, MEFMixin, ParamMixin):
 
         # Reposition annulus
         ann_obj = obj.objects[1]
-        ann_obj.move_to(ann_obj.x, self.bgycen)
+        ann_obj.move_to_pt((ann_obj.x, self.bgycen))
 
         # Reposition label
         obj.objects[2].y = (ann_obj.y + ann_obj.radius + ann_obj.width +


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/stginga/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->
Address upstream deprecation of the move_to() call on a Ginga canvas object

- the move_to(x, y) call on a canvas object has been redefined in terms of move_to_pt((x, y)) since Ginga v2.6.5.  move_to() has issued a DeprecationWarning since v4.0.0

- this fixes the plugins to use move_to_pt(). It is compatible with Ginga back to v2.6.5

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
